### PR TITLE
add Python infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# virtualenv
+venv/
+ENV/
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ OS X/iOS devices can connect to client-app (mute button and admin interface) wit
 - Zeroconf (https://pypi.python.org/pypi/zeroconf)  
 - ... and probably others
 
+### Setup
+```
+$ cd byomb
+$ virtualenv venv --python=python2
+$ pip install --requirement SERVER/requirements.txt
+```
+
 ##Clients
 HTML clients use Material Design Lite and WebSockets.
 Clients are successfully tested on recent iOS (Chrome/Firefox/Safari), recent Android (Chrome), Firefox OS 2.2, OS X/Windows (recent browser).

--- a/SERVER/requirements.txt
+++ b/SERVER/requirements.txt
@@ -1,0 +1,12 @@
+autobahn==0.14.1
+enum-compat==0.0.2
+enum34==1.1.6
+mido==1.1.14
+netifaces==0.10.4
+six==1.10.0
+Twisted==16.2.0
+txaio==2.5.1
+wheel==0.24.0
+zeroconf==0.17.5
+zope.interface==4.1.3
+


### PR DESCRIPTION
This pull request adds the usual python development infrastructure.
- `.gitignore`: add virtualenv, pip logs and compiled python files
- `requirements.txt`: a list of required python modules, based on README.md
- README: basic instructions for virtualenv and dependencies
