### PR TITLE
determine webdir independently of current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The idea behind this project is, that every podcast guest can use his/her smartp
 
 ##Server
 
-Start server with ```cd SERVER/ ; python MuteServer.py```
+Start server with ```python SERVER/MuteServer.py```
 
 ```
 usage: MuteServer.py [-h] [-p port] [-w wsport] [--rtmidi]

--- a/SERVER/MuteServer.py
+++ b/SERVER/MuteServer.py
@@ -7,6 +7,7 @@ import getopt
 import json
 import mido
 import socket
+import os
 
 from twisted.python import log
 from twisted.internet import reactor
@@ -378,8 +379,13 @@ if __name__ == '__main__':
     signal.signal(signal.SIGINT, customHandler)
     
     reactor.listenTCP(WSPORT, factory)
+
+    webdir_path = os.path.join(os.getcwd(), os.path.dirname(__file__), "../CLIENT")
+
+    if not os.path.exists(webdir_path):
+      print 'client directory not found: {}'.format(webdir_path)
     
-    webdir = File("../CLIENT")
+    webdir = File(webdir_path)
     webdir.putChild('wsport.js', WSPortJs())
     web = Site(webdir)
     reactor.listenTCP(WEBPORT, web)


### PR DESCRIPTION
This pull requests tries to determine webdir independently of current directory. It does not matter, in which the `MuteServer.py` is called: `cd SERVER; python MuteServer.py` or `python SERVER/MuteServer.py`.
